### PR TITLE
In `to_codecov`, removed call to sources, which was creating an error

### DIFF
--- a/R/codecov.R
+++ b/R/codecov.R
@@ -126,12 +126,11 @@ to_codecov <- function(x) {
   }
 
   res <- mapply(
-    function(name, source, coverage) {
+    function(name, coverage) {
       list("name" = jsonlite::unbox(name),
         "coverage" = coverage)
     },
     coverage_names,
-    sources,
     coverages,
     SIMPLIFY = FALSE,
     USE.NAMES = FALSE)


### PR DESCRIPTION
`sources` was being fed into `mapply`, but it was not being defined here, and it was not even being used.

An error was raised when I was using `codecov` with a package. With the fix on my fork, the error goes away and Codecov can receive results.
